### PR TITLE
RunningStats: support optionally returning count as bit64::integer64

### DIFF
--- a/R/running_stats.R
+++ b/R/running_stats.R
@@ -14,8 +14,8 @@
 #' large data streams.
 #'
 #' `RunningStats` is a C++ class exposed directly to \R (via
-#' `RCPP_EXPOSED_CLASS`). Methods of the class are accessed using the `$`
-#' operator.
+#' `RCPP_EXPOSED_CLASS`). Fields and methods and of the class are accessed
+#' using the `$` operator.
 #'
 #' @param na_rm Logical scalar. `TRUE` to remove `NA` from the input data (the
 #' default) or `FALSE` to retain `NA`.
@@ -43,6 +43,9 @@
 #' ## Constructor
 #' rs <- new(RunningStats, na_rm)
 #'
+#' ## Read/write fields (per-object settings)
+#' rs$returnCountAsInteger64
+#'
 #' ## Methods
 #' rs$update(newvalues)
 #' rs$get_count()
@@ -62,6 +65,15 @@
 #' Returns an object of class \code{RunningStats}. The `na_rm` argument
 #' defaults to `TRUE` if omitted.
 #'
+#' ## Read/write fields (per-object settings)
+#'
+#' \code{$returnCountAsInteger64}
+#' A logical value specifying whether to return the count of values currently
+#' in the data stream as `bit64::integer64` type. The default is `FALSE` in
+#' which case the count is returned as R `numeric` (i.e., `double`). Can be set
+#' to `TRUE` to support very large counts without loss of precision (returning
+#' the internal `int64_t` counter without a cast to `double`).
+#'
 #' ## Methods
 #'
 #' \code{$update(newvalues)}\cr
@@ -70,7 +82,9 @@
 #' for side effects.
 #'
 #' \code{$get_count()}\cr
-#' Returns the count of values received from the data stream.
+#' Returns the count of values received from the data stream. Returns a
+#' `numeric` value (i.e., `double`) unless `returnCountAsInteger64 = TRUE` in
+#' which case the count is returned as `bit64::integer64` (see above).
 #'
 #' \code{$get_mean()}\cr
 #' Returns the mean of values received from the data stream.
@@ -97,7 +111,6 @@
 #' No return value, called for side effects.
 #'
 #' @examples
-#' set.seed(42)
 #' (rs <- new(RunningStats, na_rm = TRUE))
 #'
 #' chunk <- runif(1000)
@@ -122,9 +135,10 @@
 #' rs$get_sd()
 #' sd(chunk)
 #'
+#' rs$returnCountAsInteger64 <- TRUE
 #' \donttest{
 #' ## 10^9 values read in 10,000 chunks
-#' ## should take under 1 minute on most PC hardware
+#' ## should take under 1 minute on typical hardware
 #' for (i in 1:1e4) {
 #'   chunk <- runif(1e5)
 #'   rs$update(chunk)
@@ -135,6 +149,20 @@
 #'
 #' object.size(rs)
 #' }
+#'
+#' ## large numbers with small differences
+#' rs$reset()
+#' rs$get_count()
+#'
+#' values <- runif(100000L, min = 100000000, max = 100000000.06)
+#' rs$update(values)
+#'
+#' rs$get_count()
+#'
+#' rs$get_mean() |> format(nsmall = 3, scientific = FALSE)
+#'
+#' rs$get_var()
+#' var(values)
 NULL
 
 Rcpp::loadModule("mod_running_stats", TRUE)

--- a/man/RunningStats-class.Rd
+++ b/man/RunningStats-class.Rd
@@ -27,8 +27,8 @@ stored in memory, so this class can be used to compute statistics for very
 large data streams.
 
 \code{RunningStats} is a C++ class exposed directly to \R (via
-\code{RCPP_EXPOSED_CLASS}). Methods of the class are accessed using the \code{$}
-operator.
+\code{RCPP_EXPOSED_CLASS}). Fields and methods and of the class are accessed
+using the \code{$} operator.
 }
 \note{
 The intended use is computing summary statistics for specific subsets or
@@ -47,6 +47,9 @@ computes statistics for a whole raster band.
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{## Constructor
 rs <- new(RunningStats, na_rm)
+
+## Read/write fields (per-object settings)
+rs$returnCountAsInteger64
 
 ## Methods
 rs$update(newvalues)
@@ -70,6 +73,16 @@ Returns an object of class \code{RunningStats}. The \code{na_rm} argument
 defaults to \code{TRUE} if omitted.
 }
 
+\subsection{Read/write fields (per-object settings)}{
+
+\code{$returnCountAsInteger64}
+A logical value specifying whether to return the count of values currently
+in the data stream as \code{bit64::integer64} type. The default is \code{FALSE} in
+which case the count is returned as R \code{numeric} (i.e., \code{double}). Can be set
+to \code{TRUE} to support very large counts without loss of precision (returning
+the internal \code{int64_t} counter without a cast to \code{double}).
+}
+
 \subsection{Methods}{
 
 \code{$update(newvalues)}\cr
@@ -78,7 +91,9 @@ Updates the \code{RunningStats} object with a numeric vector of \code{newvalues}
 for side effects.
 
 \code{$get_count()}\cr
-Returns the count of values received from the data stream.
+Returns the count of values received from the data stream. Returns a
+\code{numeric} value (i.e., \code{double}) unless \code{returnCountAsInteger64 = TRUE} in
+which case the count is returned as \code{bit64::integer64} (see above).
 
 \code{$get_mean()}\cr
 Returns the mean of values received from the data stream.
@@ -107,7 +122,6 @@ No return value, called for side effects.
 }
 
 \examples{
-set.seed(42)
 (rs <- new(RunningStats, na_rm = TRUE))
 
 chunk <- runif(1000)
@@ -132,9 +146,10 @@ var(chunk)
 rs$get_sd()
 sd(chunk)
 
+rs$returnCountAsInteger64 <- TRUE
 \donttest{
 ## 10^9 values read in 10,000 chunks
-## should take under 1 minute on most PC hardware
+## should take under 1 minute on typical hardware
 for (i in 1:1e4) {
   chunk <- runif(1e5)
   rs$update(chunk)
@@ -145,4 +160,18 @@ rs$get_var()
 
 object.size(rs)
 }
+
+## large numbers with small differences
+rs$reset()
+rs$get_count()
+
+values <- runif(100000L, min = 100000000, max = 100000000.06)
+rs$update(values)
+
+rs$get_count()
+
+rs$get_mean() |> format(nsmall = 3, scientific = FALSE)
+
+rs$get_var()
+var(values)
 }

--- a/src/running_stats.cpp
+++ b/src/running_stats.cpp
@@ -6,6 +6,9 @@
 #include "running_stats.h"
 
 #include <Rcpp.h>
+#include <RcppInt64>
+
+#include <vector>
 
 #include "rcpp_util.h"
 
@@ -18,12 +21,11 @@ RunningStats::RunningStats()
 RunningStats::RunningStats(bool na_rm)
         : m_na_rm(na_rm), m_count(0) {}
 
-void RunningStats::update(const Rcpp::NumericVector& newvalues) {
-    for (auto const& n : newvalues) {
-        if (m_na_rm) {
-            if (Rcpp::NumericVector::is_na(n))
-                continue;
-        }
+void RunningStats::update(const Rcpp::NumericVector &newvalues) {
+    for (auto const &n : newvalues) {
+        if (m_na_rm && Rcpp::NumericVector::is_na(n))
+            continue;
+
         m_count += 1;
         if (m_count == 1) {
             m_mean = m_min = m_max = m_sum = n;
@@ -47,9 +49,15 @@ void RunningStats::reset() {
     m_count = 0;
 }
 
-double RunningStats::get_count() const {
-    // return as double in R (no native int64)
-    return static_cast<double>(m_count);
+Rcpp::NumericVector RunningStats::get_count() const {
+    if (returnCountAsInteger64) {
+        // return as numeric vector carrying the integer64 class attribute
+        const std::vector<int64_t> ret = {m_count};
+        return Rcpp::wrap(ret);
+    }
+    else {
+        return Rcpp::wrap(static_cast<double>(m_count));
+    }
 }
 
 double RunningStats::get_mean() const {
@@ -118,6 +126,9 @@ RCPP_MODULE(mod_running_stats) {
         ("Default constructor initialized with na_rm = TRUE.")
     .constructor<bool>
         ("Initialize with na_rm = TRUE or FALSE")
+
+    // read/write fields
+    .field("returnCountAsInteger64", &RunningStats::returnCountAsInteger64)
 
     .method("update", &RunningStats::update,
         "Add new values from a numeric vector")

--- a/src/running_stats.h
+++ b/src/running_stats.h
@@ -16,11 +16,14 @@ class RunningStats {
     RunningStats();
     explicit RunningStats(bool na_rm);
 
+    // read/write field exposed to R
+    bool returnCountAsInteger64 {false};
+
+    // public methods exported to R
     void update(const Rcpp::NumericVector& newvalues);
-
     void reset();
-
-    double get_count() const;
+    // NumericVector for count to carry the optional bit64::integer64 payload
+    Rcpp::NumericVector get_count() const;
     double get_mean() const;
     double get_min() const;
     double get_max() const;
@@ -32,7 +35,8 @@ class RunningStats {
 
  private:
     bool m_na_rm;
-    uint64_t m_count;
+    // count uses signed int64 for optional return as bit64::integer64
+    int64_t m_count;
     double m_mean, m_min, m_max, m_sum;
     double m_M2;
 };

--- a/tests/testthat/test-RunningStats-class.R
+++ b/tests/testthat/test-RunningStats-class.R
@@ -1,5 +1,5 @@
 test_that("RunningStats works", {
-    set.seed(42)
+    set.seed(1)
     rs <- new(RunningStats, na_rm=TRUE)
     expect_no_error(show(rs))
     chunk <- runif(1000)
@@ -15,10 +15,11 @@ test_that("RunningStats works", {
     expect_equal(rs$get_count(), 2000)
     chunk3 <- (c(rep(NA, 10), runif(10)))
     rs$update(chunk3)
-    expect_equal(rs$get_count(), 2010)
+    rs$returnCountAsInteger64 <- TRUE
+    expect_equal(rs$get_count(), bit64::as.integer64(2010))
     expect_equal(rs$get_mean(), mean(c(chunk,chunk2,chunk3), na.rm=TRUE))
     rs$reset()
-    expect_equal(rs$get_count(), 0)
+    expect_equal(rs$get_count(), bit64::as.integer64(0))
     expect_equal(rs$get_sum(), 0)
     expect_true(is.na(rs$get_mean()))
     expect_true(is.na(rs$get_var()))


### PR DESCRIPTION
* adds per-object setting `returnCountAsInteger64` with default `FALSE` (no change in behavior, returns R `numeric`)
* if set to `TRUE`, the `get_count()` method returns a `bit64::integer64` value (i.e., does not cast the internal `int64_t` counter before return)